### PR TITLE
Composerのバージョンアップ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ docker-compose exec app bach
 ```
 #### 3.コンテナ（appサービス）に入った状態でLaravelプロジェクトを立ち上げる。
 ```
-composer create-project --prefer-dist laravel/laravel laravel_project "10.*"
+composer create-project --prefer-dist "laravel/laravel=10.*" .
+
 ```

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -8,6 +8,6 @@ RUN apt-get update && apt-get install -y \
 
 COPY ./docker/php/php.ini /usr/local/etc/php/php.ini
 
-COPY --from=composer:2.0 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.4 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /app


### PR DESCRIPTION
### 概要
- laravelの立ち上げが失敗、composerのバージョンを2.4に上げる。
- 合わせて、READMEの記載コマンドを一部修正